### PR TITLE
記事カードのリンクの当たり判定を修正

### DIFF
--- a/app/src/components/PostList/PostCard.tsx
+++ b/app/src/components/PostList/PostCard.tsx
@@ -20,12 +20,6 @@ export const PostCard: FC<PostCardProps> = ({
 }) => {
   return (
     <article className="card bg-base-200 hover:shadow-xl">
-      <a
-        href={`/articles/${slug}`}
-        className="absolute inset-0"
-        tabIndex={-1}
-        aria-label="記事に移動"
-      ></a>
       <figure
         className=" pt-4 mx-auto"
         style={{ viewTransitionName: iconTransitionName(slug) }}
@@ -47,6 +41,12 @@ export const PostCard: FC<PostCardProps> = ({
           {title}
         </h2>
         <div className="text-right">作成日 : {createdAt}</div>
+        <a
+          href={`/articles/${slug}`}
+          className="absolute inset-0"
+          tabIndex={-1}
+          aria-label="記事に移動"
+        ></a>
       </div>
     </article>
   );


### PR DESCRIPTION
絵文字付近をクリックしても遷移されるようにした

- before  
 
![before](https://github.com/tunamaguro/blog/assets/79092292/7f536947-7e2a-4189-8b51-da1cf5080b17)

- after
![after](https://github.com/tunamaguro/blog/assets/79092292/7f1120e5-2f84-4c8b-8e92-b64f379af191)
